### PR TITLE
Materialize適用による不備の修正

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -1,5 +1,6 @@
 {
   "delete_checked": "delete checked",
   "upload_files": "upload files",
-  "mkdir": "make directory"
+  "mkdir": "make directory",
+  "placeholder_folder_name": "folder name"
 }

--- a/locales/ja.json
+++ b/locales/ja.json
@@ -1,5 +1,6 @@
 {
-  "delete_checked": "チェックされたファイルを消去",
-  "upload_files": "ファイルのアップロード",
-  "mkdir": "フォルダを作成"
+	"delete_checked": "チェックされたファイルを消去",
+	"upload_files": "ファイルのアップロード",
+	"mkdir": "フォルダを作成",
+	"placeholder_folder_name": "フォルダ名"
 }

--- a/views/files/files.ejs
+++ b/views/files/files.ejs
@@ -33,9 +33,9 @@
     </form>
     <form action="<%=baseUrl%>/mkdir" method="get">
       <input type="hidden" name="path" value="<%=path %>" />
-      <input type="text" name="dir" />
+      <input type="text" name="dir" placeholder="<%= __('placeholder_folder_name') %>"/>
       <button type="submit"><%= __('mkdir') %></button>
     </form>
     <p><a href="<%=baseUrl%>/../">Back to research-ground top.</a></p>
-  </body>
+  </body>>
 </html>

--- a/views/include/_head.ejs
+++ b/views/include/_head.ejs
@@ -1,4 +1,4 @@
 <meta charset="UTF-8">
 <title><%= title %></title>
-<link rel="stylesheet" href="css/materialize.min.css">
-<script src="js/materialize.min.js"></script>
+<link rel="stylesheet" href="/css/materialize.min.css">
+<script src="/js/materialize.min.js"></script>


### PR DESCRIPTION
Materializeを適用したことによって出た以下の不備を修正しました。

- filesページのフォルダ名入力欄が水平バーに見えてしまうので、とりあえずの対処としてプレースホルダーを追加した
- Materialize の CSS, JS ファイルのURLが相対パスになっていたことによって、アクセスするURLによっては読み込みがうまくいかなかったので、CSS, JS ファイルのURLをルート相対パスに変更することによって対処した

テキスト入力欄が見えにくい問題は、レイアウト変更によって若干改善するかもしれないのですが、それでもまだ見えにくいようだったら、さらなる対処を考えます。