### PR TITLE
教師かSAのときは「管理」「採点」のメニュー項目を非表示にする

### DIFF
--- a/admin.js
+++ b/admin.js
@@ -45,6 +45,8 @@ const init = async function(rg) {
     const uid = req.session.uid;
     if (! isAdmin(uid,null)) {
       o.msg = 'You do not have parmissions to edit course data.';
+      o.teacher = req.session.teacher;
+      o.sa = req.session.sa;
       res.render('error.ejs',o);
       return;
     }
@@ -101,12 +103,16 @@ const init = async function(rg) {
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     o.id = o.name = '';
     o.msg = 'This page is for course admin.';
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     res.render('admin/courses',o);
   });
   router.get('/courses_search',loginCheck,adminCheck,async (req,res)=>{
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
+    o.teacher = req.session.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     try {
       const id = req.query.id;
       if (!id) {
@@ -133,6 +139,8 @@ const init = async function(rg) {
   router.get('/courses_regist',loginCheck,adminCheck,async (req,res)=>{
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     try {
       const id = req.query.id;
       const name = req.query.name;
@@ -157,6 +165,8 @@ const init = async function(rg) {
   router.get('/courses_del',loginCheck,adminCheck,async (req,res)=>{
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     try {
       const id = req.query.id;
       if (!id) {
@@ -194,6 +204,8 @@ const init = async function(rg) {
     const selected_course = req.query.selected_course;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     if (!selected_course) { // コースが選択されてない場合
       o.selected_course = "";
@@ -213,6 +225,8 @@ const init = async function(rg) {
     const account = req.query.account;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     if (!course || !account) { // コースやアカウントの指定がない場合
       o.selected_course = "";
@@ -231,6 +245,8 @@ const init = async function(rg) {
   router.get('/teachers_del',loginCheck,adminCheck,async (req,res)=>{
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     try {
       const course = req.query.course;
       const account = req.query.account;
@@ -271,6 +287,8 @@ const init = async function(rg) {
     const selected_course = req.query.selected_course;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     if (!selected_course) { // コースが選択されてない場合
       o.selected_course = "";
@@ -298,6 +316,8 @@ const init = async function(rg) {
     const account = req.query.account;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     if (!isAdmin(uid) && !isTeacher(uid,course)) { // 権限チェック
       o.selected_course = "";
@@ -324,6 +344,8 @@ const init = async function(rg) {
     const uid = req.session.uid;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     try {
       const course = req.query.course;
       const account = req.query.account;
@@ -371,6 +393,8 @@ const init = async function(rg) {
     const selected_course = req.query.selected_course;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     if (!selected_course) { // コースが選択されてない場合
       o.selected_course = "";
@@ -402,6 +426,8 @@ const init = async function(rg) {
     let accounts = req.body.accounts;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     if (!isAdmin(uid) && !isTeacher(uid,course)) { // 権限チェック
       o.selected_course = "";
@@ -452,6 +478,8 @@ const init = async function(rg) {
     const course = req.query.course;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     if (!isAdmin(uid) && !isTeacher(uid)) { // 権限が無い時の処理
       o.msg = `You do not have parmission to edit excercises.`;
       res.render('error',o);
@@ -491,6 +519,8 @@ const init = async function(rg) {
     const uid = req.session.uid;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     const course = req.query.course;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     o.excercises = await rg.colExcercises.find({course}).sort({label:1}).toArray();
@@ -541,6 +571,8 @@ const init = async function(rg) {
     const course = req.query.course;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     o.excercises = await rg.colExcercises.find({course}).sort({label:1}).toArray();
     if (!course) {
@@ -590,6 +622,8 @@ const init = async function(rg) {
     if (!target && !course) {
       const o = {}; // ejsにわたすデーター
       o.baseUrl = rg.config.server.mount_path;
+      o.teacher = req.session.teacher;
+      o.sa = req.session.sa;
       o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
       res.render('admin/backup',o);
       return;
@@ -597,6 +631,8 @@ const init = async function(rg) {
     if (!target) { // 通常ありえないけど
       const o = {}; // ejsにわたすデーター
       o.baseUrl = rg.config.server.mount_path;
+      o.teacher = req.session.teacher;
+      o.sa = req.session.sa;
       o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
       res.render('admin/backup',o);
       return;
@@ -652,7 +688,11 @@ const init = async function(rg) {
       msg = 'You are not logged in.';
     }
     const baseUrl = rg.config.server.mount_path;
-    res.render('admin/admin_top.ejs',{msg,baseUrl});
+    res.render('admin/admin_top.ejs', {
+      msg, baseUrl,
+      teacher: req.session.teacher,
+      sa: req.session.sa
+    });
   });
 
   return router;

--- a/admin.js
+++ b/admin.js
@@ -43,8 +43,10 @@ const init = async function(rg) {
   function adminCheck(req,res,next) {
 //if (true) {console.log('debug GAHA');next();return;} // デバッグ時に有効にすると楽
     const uid = req.session.uid;
+    const o = {}; // ejsにわたすデーター
     if (! isAdmin(uid,null)) {
       o.msg = 'You do not have parmissions to edit course data.';
+      o.baseUrl = rg.config.server.mount_path;
       o.teacher = req.session.teacher;
       o.sa = req.session.sa;
       res.render('error.ejs',o);
@@ -297,7 +299,7 @@ const init = async function(rg) {
       res.render('admin/assistants',o);
       return;
     }
-    if (!isAdmin(uid) && !isTeacher(uid,selected_course)) {
+    if (!isAdmin(uid) && !(await isTeacher(uid,selected_course))) {
       o.selected_course = "";
       o.assistants = [];
       o.msg = `You do not have parmission to edit the course(${selected_course}).`;
@@ -319,10 +321,10 @@ const init = async function(rg) {
     o.teacher = req.session.teacher;
     o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
-    if (!isAdmin(uid) && !isTeacher(uid,course)) { // 権限チェック
+    if (!isAdmin(uid) && !(await isTeacher(uid,course))) { // 権限チェック
       o.selected_course = "";
       o.assistants = [];
-      o.msg = `You do not have parmission to edit the course(${selected_course}).`;
+      o.msg = `You do not have parmission to edit the course(${course}).`;
       res.render('admin/assistants',o);
       return;
     }
@@ -350,10 +352,10 @@ const init = async function(rg) {
       const course = req.query.course;
       const account = req.query.account;
       o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
-      if (!isAdmin(uid) && !isTeacher(uid,course)) { // 権限チェック
+      if (!isAdmin(uid) && !(await isTeacher(uid,course))) { // 権限チェック
         o.selected_course = "";
         o.assistants = [];
-        o.msg = `You do not have parmission to edit the course(${selected_course}).`;
+        o.msg = `You do not have parmission to edit the course(${course}).`;
         res.render('admin/assistants',o);
         return;
       }
@@ -403,7 +405,11 @@ const init = async function(rg) {
       res.render('admin/students',o);
       return;
     }
-    if (!isAdmin(uid) && !isTeacher(uid,selected_course)) {
+console.log("GAHA1:");
+console.log("GAHA isAdmin:"+isAdmin(uid));
+console.log("GAHA isTeacher:"+await isTeacher(uid,selected_course));
+    if (!isAdmin(uid) && !(await isTeacher(uid,selected_course))) {
+console.log("GAHA2:");
       o.selected_course = "";
       o.students = "";
       o.msg = `You do not have parmission to edit the course(${selected_course}).`;
@@ -429,10 +435,10 @@ const init = async function(rg) {
     o.teacher = req.session.teacher;
     o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
-    if (!isAdmin(uid) && !isTeacher(uid,course)) { // 権限チェック
+    if (!isAdmin(uid) && !(await isTeacher(uid,course))) { // 権限チェック
       o.selected_course = "";
       o.students = "";
-      o.msg = `You do not have parmission to edit the course(${selected_course}).`;
+      o.msg = `You do not have parmission to edit the course(${course}).`;
       res.render('admin/students',o);
       return;
     }
@@ -480,7 +486,7 @@ const init = async function(rg) {
     o.baseUrl = rg.config.server.mount_path;
     o.teacher = req.session.teacher;
     o.sa = req.session.sa;
-    if (!isAdmin(uid) && !isTeacher(uid)) { // 権限が無い時の処理
+    if (!isAdmin(uid) && !(await isTeacher(uid,null))) { // 権限が無い時の処理
       o.msg = `You do not have parmission to edit excercises.`;
       res.render('error',o);
       return;
@@ -532,7 +538,7 @@ const init = async function(rg) {
       res.render('admin/excercises',o);
       return;
     }
-    if (!isAdmin(uid) && !isTeacher(uid,course)) {
+    if (!isAdmin(uid) && !(await isTeacher(uid,course))) {
       o.label=o.course=o.category="";
       o.question=o.submit=o.point="";
       o.weight=o.memo="";
@@ -583,7 +589,7 @@ const init = async function(rg) {
       res.render('admin/excercises',o);
       return;
     }
-    if (!isAdmin(uid) && !isTeacher(uid,course)) {
+    if (!isAdmin(uid) && !(await isTeacher(uid,course))) {
       o.label=o.course=o.category="";
       o.question=o.submit=o.point="";
       o.weight=o.memo="";

--- a/auth.js
+++ b/auth.js
@@ -54,7 +54,11 @@ const init = async function(rg) {
       const uid = rg.config.identity.webid2id(webid);
       if (!uid) {
         const msg = 'You do not have permission to login this server.';
-        res.render('error.ejs',{msg, baseUrl});
+        res.render('error.ejs', {
+            msg, baseUrl,
+            teacher: req.session.teacher,
+            sa: req.session.sa
+        });
         return;
       }
       let admin,teacher,sa;
@@ -84,10 +88,18 @@ const init = async function(rg) {
       if (!ret) {
         ret = rg.config.server.mount_path;
       }
-      res.render('auth/loggedin.ejs',{webid,ret,baseUrl});
+      res.render('auth/loggedin.ejs', {
+        webid, ret, baseUrl,
+        teacher: req.session.teacher,
+        sa: req.session.sa
+      });
     } catch(err) {
       const msg = err.toString();
-      res.render('error.ejs',{msg, baseUrl});
+      res.render('error.ejs', {
+        msg, baseUrl,
+        teacher: req.session.teacher,
+        sa: req.session.sa
+      });
     }
   });
 
@@ -106,6 +118,7 @@ const init = async function(rg) {
     res.clearCookie('webid');
     res.clearCookie('uid');
     res.clearCookie('admin');
+    res.clearCookie('teacher');
     res.clearCookie('sa');
     const theUrl = client.endSessionUrl(params);
     res.redirect(theUrl);
@@ -118,7 +131,11 @@ const init = async function(rg) {
       msg = 'You are not logged in.';
     }
     const baseUrl = rg.config.server.mount_path;
-    res.render('auth/auth.ejs',{msg,baseUrl});
+    res.render('auth/auth.ejs', {
+      msg, baseUrl,
+      teacher: req.session.teacher,
+      sa: req.session.sa
+    });
   });
 
   return router;

--- a/files_app.js
+++ b/files_app.js
@@ -69,7 +69,11 @@ const init = async function(rg) {
           files.unshift(parentDir);
           let c_path = path.join(rg.config.server.mount_path,'files/',req.path);
           const baseUrl = rg.config.server.mount_path;
-          res.render('files/dir_index',{c_path,files,baseUrl});
+          res.render('files/dir_index', {
+            c_path, files, baseUrl,
+            teacher: req.session.teacher,
+            sa: req.session.sa
+          });
           return;
         } else {
           const basename = path.basename(the_path);
@@ -200,6 +204,8 @@ const init = async function(rg) {
     const uid = req.session.uid;
     if (! isAdmin(uid,null)) {
       o.msg = 'You do not have parmissions to edit course data.';
+      o.teacher = req.session.teacher;
+      o.sa = req.session.sa;
       res.render('error.ejs',o);
       return;
     }
@@ -266,7 +272,11 @@ const init = async function(rg) {
     if (!req.path.startsWith(the_dir)) {
       const msg = 'You do not have permission.';
       const baseUrl = rg.config.server.mount_path;
-      res.status(403).render('error.ejs',{msg,baseUrl});
+      res.status(403).render('error.ejs', {
+        msg, baseUrl,
+        teacher: req.session.teacher,
+        sa: req.session.sa
+      });
       return;
     }
     next();
@@ -297,7 +307,9 @@ const init = async function(rg) {
       path: current_path,
       files,
       user_dir,
-      baseUrl
+      baseUrl,
+      teacher: req.session.teacher,
+      sa: req.session.sa
     };
     res.render('files/files.ejs',data);
   });
@@ -331,7 +343,9 @@ const init = async function(rg) {
       path: current_path,
       files,
       user_dir,
-      baseUrl
+      baseUrl,
+      teacher: req.session.teacher,
+      sa: req.session.sa
     };
     res.render('files/files.ejs',data);
   });
@@ -394,7 +408,9 @@ const init = async function(rg) {
       path: current_path,
       files,
       user_dir,
-      baseUrl
+      baseUrl,
+      teacher: req.session.teacher,
+      sa: req.session.sa
     };
     res.render('files/files.ejs',data);
   });
@@ -418,7 +434,9 @@ const init = async function(rg) {
       path: current_path,
       files,
       user_dir,
-      baseUrl
+      baseUrl,
+      teacher: req.session.teacher,
+      sa: req.session.sa
     };
     res.render('files/files.ejs',data);
   });

--- a/marking.js
+++ b/marking.js
@@ -45,6 +45,8 @@ const init = async function(rg) {
     const uid = req.session.uid;
     if (! isAdmin(uid,null)) {
       o.msg = 'You do not have parmissions to edit course data.';
+      o.teacher = req.session.teacher;
+      o.sa = req.session.sa;
       res.render('error.ejs',o);
       return;
     }
@@ -96,6 +98,8 @@ const init = async function(rg) {
     const uid = req.session.uid;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     const course = req.query.course;
     const label = req.query.label;
     let student = req.query.student;
@@ -171,6 +175,8 @@ const init = async function(rg) {
     const uid = req.session.uid;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     const label = req.query.label
     const course = req.query.course;
     const student = req.query.student;
@@ -302,6 +308,8 @@ console.log("GAHA: "+JSON.stringify(ret,null,2));
     const course = req.query.course;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();
     if (!course) {
       o.course = "";
@@ -332,6 +340,8 @@ console.log("GAHA: "+JSON.stringify(ret,null,2));
   router.get("/",loginCheck, (req, res) => {
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.msg = `Marking.`;
     res.render('marking/marking_top',o);
   });

--- a/marking.js
+++ b/marking.js
@@ -104,7 +104,7 @@ const init = async function(rg) {
     const label = req.query.label;
     let student = req.query.student;
     // コースの情報無しの状態でも権限が無いと判断できる場合の応答
-    if (!isAdmin(uid) && !isTeacher(uid,null) && !isAssistant(uid,null)) {
+    if (!isAdmin(uid) && !(await isTeacher(uid,null)) && !(await isAssistant(uid,null))) {
       o.msg = "You do not have permission.";
       res.render('error',o);
       return;
@@ -124,7 +124,7 @@ const init = async function(rg) {
     }
     o.excercises = await rg.colExcercises.find({course}).sort({label:1}).toArray();
     // コースの情報を含めて権限が無い場合の応答
-    if (!isAdmin(uid) && !isTeacher(uid,course) && !isAssistant(uid,course)) {
+    if (!isAdmin(uid) && !(await isTeacher(uid,course)) && !(await isAssistant(uid,course))) {
       o.students = [];
       o.course=course;
       o.label=label;
@@ -183,14 +183,14 @@ const init = async function(rg) {
     const mark = req.query.mark;
     const feedback = req.query.feedback;
     // コースの情報無しの状態でも権限が無いと判断できる場合の応答
-    if (!course && !isAdmin(uid) && !isTeacher(uid,null) && !isAssistant(uid,null)) {
+    if (!course && !isAdmin(uid) && !(await isTeacher(uid,null)) && !(await isAssistant(uid,null))) {
       o.msg = "You do not have permission.";
       res.render('error',o);
       return;
     }
     o.courses = await rg.colCourses.find({}).sort({id:1}).toArray();    
     // コースの情報を含めて権限が無い場合の応答
-    if (!isAdmin(uid) && !isTeacher(uid,course) && !isAssistant(uid,course)) {
+    if (!isAdmin(uid) && !(await isTeacher(uid,course)) && !(await isAssistant(uid,course))) {
       o.msg = "You do not have permission.";
       res.render('error',o);
       return;
@@ -227,12 +227,12 @@ const init = async function(rg) {
     const e = await colExcercises.findOne({_id: new mongo.ObjectID(excercise_id)});
     const course = e.course;
     // コースの情報無しの状態でも権限が無いと判断できる場合の応答
-    if (!course && !isAdmin(uid) && !isTeacher(uid,null) && !isAssistant(uid,null)) {
+    if (!course && !isAdmin(uid) && !(await isTeacher(uid,null)) && !(await isAssistant(uid,null))) {
       res.json({result:'error'});
       return;
     }
     // コースの情報を含めて権限が無い場合の応答
-    if (!isAdmin(uid) && !isTeacher(uid,course) && !isAssistant(uid,course)) {
+    if (!isAdmin(uid) && !(await isTeacher(uid,course)) && !(await isAssistant(uid,course))) {
       res.json({result:'error'});
       return;
     }
@@ -255,12 +255,12 @@ const init = async function(rg) {
     const e = await colExcercises.findOne({_id:f.excercise});
     const course = e?e.course:'';
     // コースの情報無しの状態でも権限が無いと判断できる場合の応答
-    if (!course && !isAdmin(uid) && !isTeacher(uid,null) && !isAssistant(uid,null)) {
+    if (!course && !isAdmin(uid) && !(await isTeacher(uid,null)) && !(await isAssistant(uid,null))) {
       res.json({result:'error'});
       return;
     }
     // コースの情報を含めて権限が無い場合の応答
-    if (!isAdmin(uid) && !isTeacher(uid,course) && !isAssistant(uid,course)) {
+    if (!isAdmin(uid) && !(await isTeacher(uid,course)) && !(await isAssistant(uid,course))) {
       res.json({result:'error'});
       return;
     }
@@ -280,12 +280,12 @@ const init = async function(rg) {
     const e = await colExcercises.findOne({_id:f.excercises});
     const course = e.course;
     // コースの情報無しの状態でも権限が無いと判断できる場合の応答
-    if (!course && !isAdmin(uid) && !isTeacher(uid,null) && !isAssistant(uid,null)) {
+    if (!course && !isAdmin(uid) && !(await isTeacher(uid,null)) && !(await isAssistant(uid,null))) {
       res.json({result:'error'});
       return;
     }
     // コースの情報を含めて権限が無い場合の応答
-    if (!isAdmin(uid) && !isTeacher(uid,course) && !isAssistant(uid,course)) {
+    if (!isAdmin(uid) && !(await isTeacher(uid,course)) && !(await isAssistant(uid,course))) {
       res.json({result:'error'});
       return;
     }

--- a/progress.js
+++ b/progress.js
@@ -35,6 +35,8 @@ const init = async function(rg) {
     const uid = req.session.uid;
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.submit_root = rg.config.server.mount_path+'files/'+rg.config.identity.classifier(uid)+uid;
     o.uploader = rg.config.server.mount_path+'files?path=';
     o.uid = uid;
@@ -74,6 +76,8 @@ console.log("GAHA: "+o.marks.length);
   router.get("/",loginCheck, (req, res) => {
     const o = {}; // ejsにわたすデーター
     o.baseUrl = rg.config.server.mount_path;
+    o.teacher = req.session.teacher;
+    o.sa = req.session.sa;
     o.msg = `Progress.`;
     res.render('progress/progress_top',o);
   });

--- a/research-ground.js
+++ b/research-ground.js
@@ -115,7 +115,12 @@ const init = async function(config_obj) {
     } else {
       str = 'You are not logged in.';
     }
-    res.render('index.ejs',{msg:str,baseUrl:config.server.mount_path});
+    res.render('index.ejs',{
+      msg: str,
+      baseUrl: config.server.mount_path,
+      teacher: req.session.teacher,
+      sa: req.session.sa
+    });
   });
 
   return app;

--- a/views/include/_nav_main.ejs
+++ b/views/include/_nav_main.ejs
@@ -2,10 +2,10 @@
     <div class="menu collection">
         <a href="<%=baseUrl%>auth" class="collection-item"><%= __("menu_auth") %></a>
         <a href="<%=baseUrl%>files" class="collection-item"><%= __("menu_files") %></a>
-        <% if (teacher) { %>
+        <% if (admin || teacher) { %>
         <a href="<%=baseUrl%>admin" class="collection-item"><%= __("menu_admin") %></a>
         <% } %>
-        <% if (teacher || sa) { %>
+        <% if (admin || teacher || sa) { %>
         <a href="<%=baseUrl%>marking" class="collection-item"><%= __("menu_marking") %></a>
         <% } %>
         <a href="<%=baseUrl%>progress" class="collection-item"><%= __("menu_progress") %></a>

--- a/views/include/_nav_main.ejs
+++ b/views/include/_nav_main.ejs
@@ -2,8 +2,10 @@
     <div class="menu collection">
         <a href="<%=baseUrl%>auth" class="collection-item"><%= __("menu_auth") %></a>
         <a href="<%=baseUrl%>files" class="collection-item"><%= __("menu_files") %></a>
-        <% if (teacher || sa) { %>
+        <% if (teacher) { %>
         <a href="<%=baseUrl%>admin" class="collection-item"><%= __("menu_admin") %></a>
+        <% } %>
+        <% if (teacher || sa) { %>
         <a href="<%=baseUrl%>marking" class="collection-item"><%= __("menu_marking") %></a>
         <% } %>
         <a href="<%=baseUrl%>progress" class="collection-item"><%= __("menu_progress") %></a>

--- a/views/include/_nav_main.ejs
+++ b/views/include/_nav_main.ejs
@@ -2,8 +2,10 @@
     <div class="menu collection">
         <a href="<%=baseUrl%>auth" class="collection-item"><%= __("menu_auth") %></a>
         <a href="<%=baseUrl%>files" class="collection-item"><%= __("menu_files") %></a>
+        <% if (teacher || sa) { %>
         <a href="<%=baseUrl%>admin" class="collection-item"><%= __("menu_admin") %></a>
         <a href="<%=baseUrl%>marking" class="collection-item"><%= __("menu_marking") %></a>
+        <% } %>
         <a href="<%=baseUrl%>progress" class="collection-item"><%= __("menu_progress") %></a>
         <a href="<%=baseUrl%>help" class="collection-item"><%= __("menu_help") %></a>
     </div>


### PR DESCRIPTION
ログインアカウントが教師かSAのときは「管理」「採点」のメニュー項目を非表示にする対応をしました。
ログアウト時にcookieのteacherがクリアされていなかったので、クリアする処理も追加しました。